### PR TITLE
🐛[#705] Properly close 'file://' resources

### DIFF
--- a/src/zeep/transports.py
+++ b/src/zeep/transports.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from contextlib import contextmanager
+from contextlib import contextmanager, closing
 from urllib.parse import urlparse
 
 import requests
@@ -114,7 +114,6 @@ class Transport:
 
         scheme = urlparse(url).scheme
         if scheme in ("http", "https", "file"):
-
             if self.cache:
                 response = self.cache.get(url)
                 if response:
@@ -133,8 +132,9 @@ class Transport:
     def _load_remote_data(self, url):
         self.logger.debug("Loading remote data from: %s", url)
         response = self.session.get(url, timeout=self.load_timeout)
-        response.raise_for_status()
-        return response.content
+        with closing(response):
+            response.raise_for_status()
+            return response.content
 
     @contextmanager
     def settings(self, timeout=None):

--- a/tests/test_transports.py
+++ b/tests/test_transports.py
@@ -49,6 +49,7 @@ def test_load_file_unix():
         result = transport.load("file:///usr/local/bin/example.wsdl")
         assert result == b"x"
         m_open.assert_called_once_with("/usr/local/bin/example.wsdl", "rb")
+        m_open.return_value.close.assert_called()
 
 
 @pytest.mark.skipif(os.name != "nt", reason="test valid for windows platform only")


### PR DESCRIPTION
I bumped into this when opening several wsdl which in turn opened lots of xsd, with 'file://' scheme.

The issue was that the `resp.raw.close` nor `resp.raw.release_conn` set in the `FileAdapter` were ever called.

It's unclear to me whether this should be fixed in requests. It doesn't do that great a job at resource management for the naive user aka Human™. It makes sense to me that exhaustively reading `Response.raw` should close it unless the caller explicitly set `stream` on the request. Probably by using this `closing` pattern in the generator in `Response.iter_content`.

Workarounds without this fix:
 - using a scheme-less url as zeep will assume it's a local path and open the file as a context manager.
 - use one of the caches from `zeep.cache` to hide duplicate open resources.