### PR TITLE
pass operation from binding to transport

### DIFF
--- a/src/zeep/transports.py
+++ b/src/zeep/transports.py
@@ -54,7 +54,7 @@ class Transport:
             get_version()
         )
 
-    def get(self, address, params, headers):
+    def get(self, address, operation, params, headers):
         """Proxy to requests.get()
 
         :param address: The URL for the request
@@ -67,7 +67,7 @@ class Transport:
         )
         return response
 
-    def post(self, address, message, headers):
+    def post(self, address, operation, message, headers):
         """Proxy to requests.posts()
 
         :param address: The URL for the request
@@ -106,7 +106,7 @@ class Transport:
 
         return response
 
-    def post_xml(self, address, envelope, headers):
+    def post_xml(self, address, operation, envelope, headers):
         """Post the envelope xml element to the given address with the headers.
 
         This method is intended to be overriden if you want to customize the
@@ -115,7 +115,7 @@ class Transport:
 
         """
         message = etree_to_string(envelope)
-        return self.post(address, message, headers)
+        return self.post(address, operation, message, headers)
 
     def load(self, url):
         """Load the content from the given URL"""
@@ -229,7 +229,7 @@ class AsyncTransport(Transport):
             raise TransportError(status_code=response.status_code)
         return result
 
-    async def post(self, address, message, headers):
+    async def post(self, address, operation, message, headers):
         self.logger.debug("HTTP Post to %s:\n%s", address, message)
         response = await self.client.post(
             address,
@@ -244,12 +244,12 @@ class AsyncTransport(Transport):
         )
         return response
 
-    async def post_xml(self, address, envelope, headers):
+    async def post_xml(self, address, operation, envelope, headers):
         message = etree_to_string(envelope)
-        response = await self.post(address, message, headers)
+        response = await self.post(address, operation, message, headers)
         return self.new_response(response)
 
-    async def get(self, address, params, headers):
+    async def get(self, address, operation, params, headers):
         response = await self.client.get(
             address,
             params=params,

--- a/src/zeep/wsdl/bindings/http.py
+++ b/src/zeep/wsdl/bindings/http.py
@@ -67,7 +67,7 @@ class HttpPostBinding(HttpBinding):
 
         url = options["address"] + serialized.path
         response = client.transport.post(
-            url, serialized.content, headers=serialized.headers
+            url, operation, serialized.content, headers=serialized.headers
         )
         return self.process_reply(client, operation_obj, response)
 
@@ -95,7 +95,7 @@ class HttpGetBinding(HttpBinding):
 
         url = options["address"] + serialized.path
         response = client.transport.get(
-            url, serialized.content, headers=serialized.headers
+            url, operation, serialized.content, headers=serialized.headers
         )
         return self.process_reply(client, operation_obj, response)
 

--- a/src/zeep/wsdl/bindings/soap.py
+++ b/src/zeep/wsdl/bindings/soap.py
@@ -124,7 +124,7 @@ class SoapBinding(Binding):
             operation, args, kwargs, client=client, options=options
         )
 
-        response = client.transport.post_xml(options["address"], envelope, http_headers)
+        response = client.transport.post_xml(options["address"], operation, envelope, http_headers)
 
         operation_obj = self.get(operation)
 
@@ -154,7 +154,7 @@ class SoapBinding(Binding):
         )
 
         response = await client.transport.post_xml(
-            options["address"], envelope, http_headers
+            options["address"], operation, envelope, http_headers
         )
 
         if client.settings.raw_response:

--- a/tests/test_async_transport.py
+++ b/tests/test_async_transport.py
@@ -47,7 +47,7 @@ async def test_post(httpx_mock: HTTPXMock):
 
     httpx_mock.add_response(url="http://tests.python-zeep.org/test.xml", content="x")
     result = await transport.post_xml(
-        "http://tests.python-zeep.org/test.xml", envelope=envelope, headers={}
+        "http://tests.python-zeep.org/test.xml", "operation", envelope=envelope, headers={}
     )
 
     assert result.content == b"x"


### PR DESCRIPTION
This passes the operation name to the Transport. The API I'm working with needs this at the transport level in HTTP header for the raw XML version, or the query string in the SOAP version.

Sample XML API that requires this (X-EBAY-API-CALL-NAME) - https://developer.ebay.com/api-docs/user-guides/static/make-a-call/using-xml.html#headers

Sample SOAP API that requires this (callname parameter) - https://developer.ebay.com/api-docs/user-guides/static/make-a-call/using-soap.html#parameters